### PR TITLE
Fix missing prompt support for topic generation

### DIFF
--- a/openai.js
+++ b/openai.js
@@ -408,17 +408,18 @@ class OpenAIService {
    * @param {string} systemPrompt
    * @returns {Promise<Array<string>>}
    */
-  async generateSearchTopics(title, systemPrompt) {
+  async generateSearchTopics(title, prompt, systemPrompt) {
     const defaultSystemPrompt = 'You are an investigative journalist brainstorming sub-topics to research a subject on the web.';
     const finalSystemPrompt = systemPrompt || defaultSystemPrompt;
 
-    const userPrompt = `Propose 5 distinct, concise search queries that would help someone research the topic "${title}" thoroughly.\nReturn them as a simple numbered list.`;
+    const defaultUserPrompt = `Propose 5 distinct, concise search queries that would help someone research the topic "${title}" thoroughly.\nReturn them as a simple numbered list.`;
+    const finalUserPrompt = prompt || defaultUserPrompt;
 
     const response = await this.client.chat.completions.create({
       model: 'gpt-4o',
       messages: [
         { role: 'system', content: finalSystemPrompt },
-        { role: 'user', content: userPrompt }
+        { role: 'user', content: finalUserPrompt }
       ],
       temperature: 0.7,
       max_tokens: 300

--- a/topics.js
+++ b/topics.js
@@ -9,14 +9,14 @@ const OpenAIService = require('./openai');
 // POST /api/topics
 router.post('/', async (req, res) => {
   try {
-    const { title, systemPrompt, apiKey } = req.body;
+    const { title, prompt, systemPrompt, apiKey } = req.body;
 
     if (!title) {
       return res.status(400).json({ error: 'Title is required' });
     }
 
     const openaiService = new OpenAIService(apiKey);
-    const topics = await openaiService.generateSearchTopics(title, systemPrompt);
+    const topics = await openaiService.generateSearchTopics(title, prompt, systemPrompt);
 
     res.json({ topics });
   } catch (error) {


### PR DESCRIPTION
## Summary
- allow passing a custom user prompt when generating search topics
- plumb the prompt through the `/api/topics` endpoint to `OpenAIService`

## Testing
- `node --check openai.js`
- `node --check topics.js`
- `npm test` *(fails: missing script)*